### PR TITLE
Add localization support for admin content templates

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -75,4 +75,7 @@ $config = [
 // Store configuration in global variable
 $GLOBALS['config'] = $config;
 
+// Load helper functions (including localization)
+require_once APP_PATH . '/core/helpers.php';
+
 return $config;

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -1,0 +1,49 @@
+<?php
+if (!function_exists('app_locale')) {
+    function app_locale(): string
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            @session_start();
+        }
+        if (!empty($_SESSION['locale'])) {
+            return (string)$_SESSION['locale'];
+        }
+        if (!empty($_COOKIE['locale'])) {
+            return (string)$_COOKIE['locale'];
+        }
+        return $GLOBALS['config']['app']['locale'] ?? 'en';
+    }
+}
+
+if (!function_exists('__')) {
+    function __(string $key, array $replace = [], ?string $locale = null): string
+    {
+        static $translations = [];
+        $locale = $locale ?: app_locale();
+        if (!isset($translations[$locale])) {
+            $path = APP_PATH . '/lang/' . $locale . '.php';
+            $translations[$locale] = file_exists($path) ? include $path : [];
+        }
+
+        $segments = explode('.', $key);
+        $value = $translations[$locale];
+        foreach ($segments as $segment) {
+            if (is_array($value) && array_key_exists($segment, $value)) {
+                $value = $value[$segment];
+            } else {
+                $value = $key;
+                break;
+            }
+        }
+
+        if (!is_string($value)) {
+            $value = $key;
+        }
+
+        foreach ($replace as $search => $replacement) {
+            $value = str_replace(':' . $search, (string)$replacement, $value);
+        }
+
+        return $value;
+    }
+}

--- a/lang/ar.php
+++ b/lang/ar.php
@@ -1,0 +1,121 @@
+<?php
+return [
+    'common' => [
+        'actions' => [
+            'back' => 'عودة',
+            'cancel' => 'إلغاء',
+            'delete' => 'حذف',
+            'edit' => 'تعديل',
+            'filter' => 'تصفية',
+        ],
+        'filters' => [
+            'all_statuses' => 'كل الحالات',
+        ],
+        'table' => [
+            'no_records' => 'لا توجد سجلات',
+        ],
+        'time' => [
+            'minutes_short' => 'د',
+        ],
+        'forms' => [
+            'characters' => 'حرف',
+        ],
+    ],
+    'admin' => [
+        'content' => [
+            'status' => [
+                'draft' => 'مسودة',
+                'published' => 'منشور',
+                'archived' => 'مؤرشف',
+                'unknown' => 'غير معروف',
+            ],
+            'index' => [
+                'title' => 'إدارة المحتوى التوعوي',
+                'subtitle' => 'إضافة وتحرير المحتوى التوعوي في المنصة',
+                'buttons' => [
+                    'create' => 'إضافة محتوى جديد',
+                ],
+                'filters' => [
+                    'search_placeholder' => 'البحث في المحتوى...',
+                    'type_placeholder' => 'النوع (article/video/pdf)',
+                ],
+                'table' => [
+                    'headers' => [
+                        'title' => 'عنوان المحتوى',
+                        'type' => 'النوع',
+                        'points' => 'النقاط',
+                        'duration' => 'المدة',
+                        'status' => 'الحالة',
+                        'actions' => 'الإجراءات',
+                    ],
+                ],
+                'confirm_delete' => 'حذف هذا المحتوى؟',
+            ],
+            'create' => [
+                'title' => 'إنشاء محتوى',
+                'subtitle' => 'أضف مواد التوعية بالمؤسسة',
+                'buttons' => [
+                    'submit' => 'نشر المحتوى',
+                ],
+                'console' => [
+                    'error_code' => 'رمز الخطأ',
+                    'creation_errors' => 'أخطاء إنشاء المحتوى',
+                    'dev_details_title' => 'تفاصيل تقنية (للتشخيص المحلي فقط)',
+                    'type_label' => 'النوع:',
+                    'message_label' => 'الرسالة:',
+                    'sqlstate_label' => 'SQLSTATE:',
+                    'driver_label' => 'Driver:',
+                    'time_label' => 'الوقت:',
+                ],
+                'form' => [
+                    'title_label' => 'عنوان المحتوى',
+                    'title_placeholder' => 'مثال: أهم ممارسات أمان كلمة المرور',
+                    'category_label' => 'الفئة',
+                    'category_aria' => 'اختيار الفئة',
+                    'category_placeholder' => 'اختر الفئة',
+                    'default_categories' => [
+                        'basic_security' => 'الحماية الأساسية',
+                        'email_security' => 'أمان البريد الإلكتروني',
+                        'mobile_security' => 'حماية الأجهزة المحمولة',
+                        'password_management' => 'إدارة كلمات المرور',
+                        'network_security' => 'أمان الشبكات',
+                        'cloud_storage' => 'التخزين السحابي',
+                    ],
+                    'type_label' => 'نوع المحتوى',
+                    'type_aria' => 'نوع المحتوى',
+                    'type_options' => [
+                        'article' => 'محتوى نصي',
+                        'video' => 'محتوى فيديو',
+                    ],
+                    'type_help' => 'اختر النوع المناسب ليتم عرض الحقول ذات الصلة فقط.',
+                    'article_body_label' => 'المحتوى النصي',
+                    'article_body_placeholder' => 'اكتب المحتوى هنا... (يدعم النصوص الطويلة)',
+                    'article_body_hint' => 'سيتم الحفظ في الحقل `body` ضمن جدول المحتوى.',
+                    'media_url_label' => 'رابط الوسائط (media_url)',
+                    'media_url_placeholder' => 'أدخل رابط الوسائط: YouTube, Vimeo, أو ملف خارجي',
+                    'media_url_hint' => 'مثال: https://www.youtube.com/watch?v=xxxx — سيتم الحفظ في `media_url`.',
+                    'description_label' => 'وصف المحتوى',
+                    'description_placeholder' => 'اكتب وصفًا مختصرًا للمحتوى...',
+                    'difficulty_label' => 'مستوى الصعوبة',
+                    'difficulty_placeholder' => 'اختر المستوى',
+                    'difficulty_options' => [
+                        'beginner' => 'مبتدئ',
+                        'intermediate' => 'متوسط',
+                        'advanced' => 'متقدم',
+                    ],
+                    'duration_label' => 'وقت القراءة/المشاهدة المتوقع (بالدقائق)',
+                    'duration_placeholder' => 'مثال: 5',
+                    'points_label' => 'نقاط المكافأة',
+                    'status_label' => 'حالة النشر',
+                    'thumbnail_label' => 'رابط الصورة المصغرة (thumbnail_url)',
+                    'thumbnail_placeholder' => 'https://...',
+                    'featured_label' => 'محتوى مميز',
+                ],
+                'alerts' => [
+                    'body_required' => 'يرجى كتابة المحتوى النصي.',
+                    'media_required' => 'يرجى إدراج رابط الوسائط المناسب لهذا النوع.',
+                ],
+            ],
+        ],
+    ],
+];

--- a/lang/en.php
+++ b/lang/en.php
@@ -1,0 +1,121 @@
+<?php
+return [
+    'common' => [
+        'actions' => [
+            'back' => 'Back',
+            'cancel' => 'Cancel',
+            'delete' => 'Delete',
+            'edit' => 'Edit',
+            'filter' => 'Filter',
+        ],
+        'filters' => [
+            'all_statuses' => 'All statuses',
+        ],
+        'table' => [
+            'no_records' => 'No records found',
+        ],
+        'time' => [
+            'minutes_short' => 'min',
+        ],
+        'forms' => [
+            'characters' => 'characters',
+        ],
+    ],
+    'admin' => [
+        'content' => [
+            'status' => [
+                'draft' => 'Draft',
+                'published' => 'Published',
+                'archived' => 'Archived',
+                'unknown' => 'Unknown',
+            ],
+            'index' => [
+                'title' => 'Awareness Content Management',
+                'subtitle' => 'Add and edit awareness materials on the platform',
+                'buttons' => [
+                    'create' => 'Add New Content',
+                ],
+                'filters' => [
+                    'search_placeholder' => 'Search content...',
+                    'type_placeholder' => 'Type (article/video/pdf)',
+                ],
+                'table' => [
+                    'headers' => [
+                        'title' => 'Content Title',
+                        'type' => 'Type',
+                        'points' => 'Points',
+                        'duration' => 'Duration',
+                        'status' => 'Status',
+                        'actions' => 'Actions',
+                    ],
+                ],
+                'confirm_delete' => 'Delete this content?',
+            ],
+            'create' => [
+                'title' => 'Create Content',
+                'subtitle' => 'Add awareness materials for the organization',
+                'buttons' => [
+                    'submit' => 'Publish Content',
+                ],
+                'console' => [
+                    'error_code' => 'Error code',
+                    'creation_errors' => 'Content creation errors',
+                    'dev_details_title' => 'Technical details (local debugging only)',
+                    'type_label' => 'Type:',
+                    'message_label' => 'Message:',
+                    'sqlstate_label' => 'SQLSTATE:',
+                    'driver_label' => 'Driver:',
+                    'time_label' => 'Time:',
+                ],
+                'form' => [
+                    'title_label' => 'Content title',
+                    'title_placeholder' => 'Example: Top password security practices',
+                    'category_label' => 'Category',
+                    'category_aria' => 'Select category',
+                    'category_placeholder' => 'Choose a category',
+                    'default_categories' => [
+                        'basic_security' => 'Basic protection',
+                        'email_security' => 'Email security',
+                        'mobile_security' => 'Mobile device protection',
+                        'password_management' => 'Password management',
+                        'network_security' => 'Network security',
+                        'cloud_storage' => 'Cloud storage',
+                    ],
+                    'type_label' => 'Content type',
+                    'type_aria' => 'Content type',
+                    'type_options' => [
+                        'article' => 'Text content',
+                        'video' => 'Video content',
+                    ],
+                    'type_help' => 'Choose the appropriate type to show only the relevant fields.',
+                    'article_body_label' => 'Text content',
+                    'article_body_placeholder' => 'Write the content here... (long text supported)',
+                    'article_body_hint' => 'Will be stored in the `body` column of the content table.',
+                    'media_url_label' => 'Media URL (media_url)',
+                    'media_url_placeholder' => 'Enter a media link: YouTube, Vimeo, or external file',
+                    'media_url_hint' => 'Example: https://www.youtube.com/watch?v=xxxx — stored in `media_url`.',
+                    'description_label' => 'Content description',
+                    'description_placeholder' => 'Write a brief description for the content...',
+                    'difficulty_label' => 'Difficulty level',
+                    'difficulty_placeholder' => 'Choose a level',
+                    'difficulty_options' => [
+                        'beginner' => 'Beginner',
+                        'intermediate' => 'Intermediate',
+                        'advanced' => 'Advanced',
+                    ],
+                    'duration_label' => 'Expected reading/viewing time (minutes)',
+                    'duration_placeholder' => 'Example: 5',
+                    'points_label' => 'Reward points',
+                    'status_label' => 'Publication status',
+                    'thumbnail_label' => 'Thumbnail URL (thumbnail_url)',
+                    'thumbnail_placeholder' => 'https://...',
+                    'featured_label' => 'Featured content',
+                ],
+                'alerts' => [
+                    'body_required' => 'Please write the text content.',
+                    'media_required' => 'Please provide the appropriate media link for this type.',
+                ],
+            ],
+        ],
+    ],
+];

--- a/views/admin/content/create.php
+++ b/views/admin/content/create.php
@@ -7,11 +7,11 @@ if ($basePath === '/' || $basePath === '\\') { $basePath = ''; }
     <div class="flex items-center">
       <div class="w-10 h-10 bg-[#1E3D59]/10 rounded-lg flex items-center justify-center mr-3"><i class="ri-file-add-line text-[#1E3D59] text-xl"></i></div>
       <div>
-        <h1 class="text-xl md:text-2xl font-bold text-gray-900">إنشاء محتوى</h1>
-        <p class="text-sm text-gray-600">أضف مواد التوعية بالمؤسسة</p>
+        <h1 class="text-xl md:text-2xl font-bold text-gray-900"><?= __('admin.content.create.title') ?></h1>
+        <p class="text-sm text-gray-600"><?= __('admin.content.create.subtitle') ?></p>
       </div>
     </div>
-    <a href="<?= $basePath ?>/admin/content" class="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50">عودة</a>
+    <a href="<?= $basePath ?>/admin/content" class="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50"><?= __('common.actions.back') ?></a>
   </div>
 </div>
 
@@ -19,7 +19,7 @@ if ($basePath === '/' || $basePath === '\\') { $basePath = ''; }
   <script>
     (function(){
       try {
-        console.group('%cرمز الخطأ','color:#b91c1c;font-weight:bold;');
+        console.group('%c' + <?= json_encode(__('admin.content.create.console.error_code')) ?>,'color:#b91c1c;font-weight:bold;');
         console.error('<?= htmlspecialchars($_GET['error']) ?>');
         console.groupEnd();
       } catch(_){}
@@ -32,7 +32,7 @@ if ($basePath === '/' || $basePath === '\\') { $basePath = ''; }
     (function(){
       try {
         const errs = <?= json_encode($errors, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
-        console.group('%cأخطاء إنشاء المحتوى','color:#b91c1c;font-weight:bold;');
+        console.group('%c' + <?= json_encode(__('admin.content.create.console.creation_errors')) ?>,'color:#b91c1c;font-weight:bold;');
         errs.forEach(e=>console.error(e));
         console.groupEnd();
       } catch(_){}
@@ -45,12 +45,12 @@ if ($basePath === '/' || $basePath === '\\') { $basePath = ''; }
     (function(){
       try {
         const detail = <?= json_encode($devError, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
-        console.group('%cتفاصيل تقنية (للتشخيص المحلي فقط)','color:#334155;font-weight:bold;');
-        console.info('النوع:', detail.type || '');
-        console.info('الرسالة:', detail.message || '');
-        if (detail.sqlstate) console.info('SQLSTATE:', detail.sqlstate);
-        if (detail.driver) console.info('Driver:', detail.driver);
-        console.info('الوقت:', detail.time || '');
+        console.group('%c' + <?= json_encode(__('admin.content.create.console.dev_details_title')) ?>,'color:#334155;font-weight:bold;');
+        console.info(<?= json_encode(__('admin.content.create.console.type_label')) ?>, detail.type || '');
+        console.info(<?= json_encode(__('admin.content.create.console.message_label')) ?>, detail.message || '');
+        if (detail.sqlstate) console.info(<?= json_encode(__('admin.content.create.console.sqlstate_label')) ?>, detail.sqlstate);
+        if (detail.driver) console.info(<?= json_encode(__('admin.content.create.console.driver_label')) ?>, detail.driver);
+        console.info(<?= json_encode(__('admin.content.create.console.time_label')) ?>, detail.time || '');
         console.groupEnd();
       } catch(_){}
     })();
@@ -66,13 +66,13 @@ if ($basePath === '/' || $basePath === '\\') { $basePath = ''; }
   <!-- معلومات أساسية -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-2">عنوان المحتوى</label>
-      <input type="text" name="title" value="<?= htmlspecialchars($old['title'] ?? '') ?>" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" placeholder="مثال: أهم ممارسات أمان كلمة المرور" required>
+      <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.title_label') ?></label>
+      <input type="text" name="title" value="<?= htmlspecialchars($old['title'] ?? '') ?>" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" placeholder="<?= __('admin.content.create.form.title_placeholder') ?>" required>
     </div>
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-2">الفئة</label>
-      <select name="category_id" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" aria-label="اختيار الفئة">
-        <option value="">اختر الفئة</option>
+      <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.category_label') ?></label>
+      <select name="category_id" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" aria-label="<?= __('admin.content.create.form.category_aria') ?>">
+        <option value=""><?= __('admin.content.create.form.category_placeholder') ?></option>
         <?php if (!empty($categories ?? [])): ?>
           <?php foreach ($categories as $cat): ?>
             <option value="<?= (int)$cat['id'] ?>" <?= (isset($old['category_id']) && (int)$old['category_id']===(int)$cat['id'])?'selected':''; ?>>
@@ -80,12 +80,12 @@ if ($basePath === '/' || $basePath === '\\') { $basePath = ''; }
             </option>
           <?php endforeach; ?>
         <?php else: ?>
-          <option value="1">الحماية الأساسية</option>
-          <option value="2">أمان البريد الإلكتروني</option>
-          <option value="3">حماية الأجهزة المحمولة</option>
-          <option value="4">إدارة كلمات المرور</option>
-          <option value="5">أمان الشبكات</option>
-          <option value="6">التخزين السحابي</option>
+          <option value="1"><?= __('admin.content.create.form.default_categories.basic_security') ?></option>
+          <option value="2"><?= __('admin.content.create.form.default_categories.email_security') ?></option>
+          <option value="3"><?= __('admin.content.create.form.default_categories.mobile_security') ?></option>
+          <option value="4"><?= __('admin.content.create.form.default_categories.password_management') ?></option>
+          <option value="5"><?= __('admin.content.create.form.default_categories.network_security') ?></option>
+          <option value="6"><?= __('admin.content.create.form.default_categories.cloud_storage') ?></option>
         <?php endif; ?>
       </select>
     </div>
@@ -93,28 +93,28 @@ if ($basePath === '/' || $basePath === '\\') { $basePath = ''; }
 
   <!-- نوع المحتوى -->
   <div>
-    <label class="block text-sm font-medium text-gray-700 mb-2">نوع المحتوى</label>
-    <div class="flex flex-wrap gap-3 mb-2" role="tablist" aria-label="نوع المحتوى">
-      <button type="button" id="btnText" class="px-4 py-2 text-sm rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-100" aria-selected="false">محتوى نصي</button>
-      <button type="button" id="btnVideo" class="px-4 py-2 text-sm rounded-lg text-white" style="background:#1E3D59;" aria-selected="true">محتوى فيديو</button>
+    <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.type_label') ?></label>
+    <div class="flex flex-wrap gap-3 mb-2" role="tablist" aria-label="<?= __('admin.content.create.form.type_aria') ?>">
+      <button type="button" id="btnText" class="px-4 py-2 text-sm rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-100" aria-selected="false"><?= __('admin.content.create.form.type_options.article') ?></button>
+      <button type="button" id="btnVideo" class="px-4 py-2 text-sm rounded-lg text-white" style="background:#1E3D59;" aria-selected="true"><?= __('admin.content.create.form.type_options.video') ?></button>
       
     </div>
-    <p id="typeHelp" class="text-xs text-gray-500">اختر النوع المناسب ليتم عرض الحقول ذات الصلة فقط.</p>
+    <p id="typeHelp" class="text-xs text-gray-500"><?= __('admin.content.create.form.type_help') ?></p>
 
     <!-- القسم النصي -->
     <div id="textSection" class="hidden mt-4">
-      <label class="block text-sm font-medium text-gray-700 mb-2">المحتوى النصي</label>
-      <textarea id="textBody" rows="8" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" placeholder="اكتب المحتوى هنا... (يدعم النصوص الطويلة)"></textarea>
-      <p class="text-xs text-gray-500 mt-1">سيتم الحفظ في الحقل `body` ضمن جدول المحتوى.</p>
+      <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.article_body_label') ?></label>
+      <textarea id="textBody" rows="8" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" placeholder="<?= __('admin.content.create.form.article_body_placeholder') ?>"></textarea>
+      <p class="text-xs text-gray-500 mt-1"><?= __('admin.content.create.form.article_body_hint') ?></p>
     </div>
 
     <!-- القسم المرئي (فيديو/دليل/إنفوجرافيك) -->
     <div id="mediaSection" class="mt-4">
-      <label class="block text-sm font-medium text-gray-700 mb-2">رابط الوسائط (media_url)</label>
+      <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.media_url_label') ?></label>
       <div class="border border-gray-200 rounded-lg p-4">
         <div class="flex flex-col gap-3 max-w-xl">
-          <input type="url" id="videoUrl" placeholder="أدخل رابط الوسائط: YouTube, Vimeo, أو ملف خارجي" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]">
-          <div class="text-xs text-gray-500">مثال: https://www.youtube.com/watch?v=xxxx — سيتم الحفظ في `media_url`.</div>
+          <input type="url" id="videoUrl" placeholder="<?= __('admin.content.create.form.media_url_placeholder') ?>" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]">
+          <div class="text-xs text-gray-500"><?= __('admin.content.create.form.media_url_hint') ?></div>
         </div>
       </div>
     </div>
@@ -122,61 +122,61 @@ if ($basePath === '/' || $basePath === '\\') { $basePath = ''; }
 
   <!-- الوصف والإعدادات -->
   <div>
-    <label class="block text-sm font-medium text-gray-700 mb-2">وصف المحتوى</label>
-    <textarea id="descTextarea" name="description" rows="4" maxlength="500" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" placeholder="اكتب وصفًا مختصرًا للمحتوى...">&ZeroWidthSpace;<?= htmlspecialchars($old['description'] ?? '') ?></textarea>
-    <div class="text-xs text-gray-500 mt-1"><span id="descCount">0</span>/500 حرف</div>
+    <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.description_label') ?></label>
+    <textarea id="descTextarea" name="description" rows="4" maxlength="500" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" placeholder="<?= __('admin.content.create.form.description_placeholder') ?>">&ZeroWidthSpace;<?= htmlspecialchars($old['description'] ?? '') ?></textarea>
+    <div class="text-xs text-gray-500 mt-1"><span id="descCount">0</span>/500 <?= __('common.forms.characters') ?></div>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-2">مستوى الصعوبة</label>
+      <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.difficulty_label') ?></label>
       <?php $ps = $old['difficulty_level'] ?? ''; ?>
       <select name="difficulty_level" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]">
-        <option value="">اختر المستوى</option>
-        <option value="beginner" <?= $ps==='beginner'?'selected':''; ?>>مبتدئ</option>
-        <option value="intermediate" <?= $ps==='intermediate'?'selected':''; ?>>متوسط</option>
-        <option value="advanced" <?= $ps==='advanced'?'selected':''; ?>>متقدم</option>
+        <option value=""><?= __('admin.content.create.form.difficulty_placeholder') ?></option>
+        <option value="beginner" <?= $ps==='beginner'?'selected':''; ?>><?= __('admin.content.create.form.difficulty_options.beginner') ?></option>
+        <option value="intermediate" <?= $ps==='intermediate'?'selected':''; ?>><?= __('admin.content.create.form.difficulty_options.intermediate') ?></option>
+        <option value="advanced" <?= $ps==='advanced'?'selected':''; ?>><?= __('admin.content.create.form.difficulty_options.advanced') ?></option>
       </select>
     </div>
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-2">وقت القراءة/المشاهدة المتوقع (بالدقائق)</label>
-      <input type="number" name="est_duration" value="<?= htmlspecialchars((string)($old['est_duration'] ?? 0)) ?>" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" min="0" placeholder="مثال: 5">
+      <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.duration_label') ?></label>
+      <input type="number" name="est_duration" value="<?= htmlspecialchars((string)($old['est_duration'] ?? 0)) ?>" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" min="0" placeholder="<?= __('admin.content.create.form.duration_placeholder') ?>">
     </div>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-2">نقاط المكافأة</label>
+      <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.points_label') ?></label>
       <input type="number" name="reward_points" value="<?= htmlspecialchars((string)($old['reward_points'] ?? 0)) ?>" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" min="0">
     </div>
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-2">حالة النشر</label>
+      <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.status_label') ?></label>
       <?php $ps = $old['publish_status'] ?? 'draft'; ?>
       <select name="publish_status" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]">
-        <option value="draft" <?= $ps==='draft'?'selected':''; ?>>مسودة</option>
-        <option value="published" <?= $ps==='published'?'selected':''; ?>>منشور</option>
-        <option value="archived" <?= $ps==='archived'?'selected':''; ?>>مؤرشف</option>
+        <option value="draft" <?= $ps==='draft'?'selected':''; ?>><?= __('admin.content.status.draft') ?></option>
+        <option value="published" <?= $ps==='published'?'selected':''; ?>><?= __('admin.content.status.published') ?></option>
+        <option value="archived" <?= $ps==='archived'?'selected':''; ?>><?= __('admin.content.status.archived') ?></option>
       </select>
     </div>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-2">رابط الصورة المصغرة (thumbnail_url)</label>
-      <input type="url" name="thumbnail_url" value="<?= htmlspecialchars($old['thumbnail_url'] ?? '') ?>" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" placeholder="https://...">
+      <label class="block text-sm font-medium text-gray-700 mb-2"><?= __('admin.content.create.form.thumbnail_label') ?></label>
+      <input type="url" name="thumbnail_url" value="<?= htmlspecialchars($old['thumbnail_url'] ?? '') ?>" class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1E3D59]/20 focus:border-[#1E3D59]" placeholder="<?= __('admin.content.create.form.thumbnail_placeholder') ?>">
     </div>
   </div>
 
   <div class="flex items-center gap-3">
     <label class="inline-flex items-center gap-2 text-sm text-gray-700">
       <input type="checkbox" name="is_featured" value="1" <?= !empty($old['is_featured']) ? 'checked' : '' ?> class="w-4 h-4">
-      محتوى مميز
+      <?= __('admin.content.create.form.featured_label') ?>
     </label>
   </div>
 
   <div class="flex items-center justify-end gap-3 mt-6">
-    <a href="<?= $basePath ?>/admin/content" class="bg-gray-200 text-gray-700 px-6 py-2 rounded hover:bg-gray-300">إلغاء</a>
-    <button type="submit" class="bg-[#1E3D59] text-white px-6 py-2 rounded hover:opacity-90">نشر المحتوى</button>
+    <a href="<?= $basePath ?>/admin/content" class="bg-gray-200 text-gray-700 px-6 py-2 rounded hover:bg-gray-300"><?= __('common.actions.cancel') ?></a>
+    <button type="submit" class="bg-[#1E3D59] text-white px-6 py-2 rounded hover:opacity-90"><?= __('admin.content.create.buttons.submit') ?></button>
   </div>
 </form>
 
@@ -248,7 +248,7 @@ if ($basePath === '/' || $basePath === '\\') { $basePath = ''; }
         mediaUrlHidden.value = '';
         bodyHidden.value = (textBody.value || '').trim();
         if (!bodyHidden.value){
-          alert('يرجى كتابة المحتوى النصي.');
+          alert(<?= json_encode(__('admin.content.create.alerts.body_required')) ?>);
           e.preventDefault();
           return;
         }
@@ -256,7 +256,7 @@ if ($basePath === '/' || $basePath === '\\') { $basePath = ''; }
         bodyHidden.value = '';
         mediaUrlHidden.value = (videoUrl.value || '').trim();
         if (!mediaUrlHidden.value){
-          alert('يرجى إدراج رابط الوسائط المناسب لهذا النوع.');
+          alert(<?= json_encode(__('admin.content.create.alerts.media_required')) ?>);
           e.preventDefault();
           return;
         }

--- a/views/admin/content/index.php
+++ b/views/admin/content/index.php
@@ -13,11 +13,11 @@ $isAdmin = (session_status() === PHP_SESSION_ACTIVE || @session_start() === null
           <i class="ri-file-list-2-line"></i>
         </div>
         <div>
-          <h1 class="text-3xl font-bold text-gray-900">إدارة المحتوى التوعوي</h1>
-          <p class="text-base text-gray-600">إضافة وتحرير المحتوى التوعوي في المنصة</p>
+          <h1 class="text-3xl font-bold text-gray-900"><?= __('admin.content.index.title') ?></h1>
+          <p class="text-base text-gray-600"><?= __('admin.content.index.subtitle') ?></p>
         </div>
       </div>
-      <a href="<?= $basePath ?>/admin/content/create" class="btn btn-primary">إضافة محتوى جديد</a>
+      <a href="<?= $basePath ?>/admin/content/create" class="btn btn-primary"><?= __('admin.content.index.buttons.create') ?></a>
     </div>
   </div>
 </div>
@@ -29,22 +29,22 @@ $isAdmin = (session_status() === PHP_SESSION_ACTIVE || @session_start() === null
       <div class="relative flex-1 max-w-xl">
         <span class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400"><i class="ri-search-line"></i></span>
         <input type="text" name="q" value="<?= htmlspecialchars($q ?? '') ?>"
-               placeholder="البحث في المحتوى..."
+               placeholder="<?= __('admin.content.index.filters.search_placeholder') ?>"
                class="form-input w-full pr-10 pl-4 py-2">
       </div>
 
-      <input type="text" name="type" value="<?= htmlspecialchars($type ?? '') ?>" placeholder="النوع (article/video/pdf)"
+      <input type="text" name="type" value="<?= htmlspecialchars($type ?? '') ?>" placeholder="<?= __('admin.content.index.filters.type_placeholder') ?>"
              class="form-input w-full md:w-48 px-4 py-2">
 
       <?php $st = $status ?? ''; ?>
       <select name="publish_status" class="form-select w-full md:w-48 px-4 py-2">
-        <option value="" <?= $st===''?'selected':''; ?>>كل الحالات</option>
-        <option value="draft" <?= $st==='draft'?'selected':''; ?>>مسودة</option>
-        <option value="published" <?= $st==='published'?'selected':''; ?>>منشور</option>
-        <option value="archived" <?= $st==='archived'?'selected':''; ?>>مؤرشف</option>
+        <option value="" <?= $st===''?'selected':''; ?>><?= __('common.filters.all_statuses') ?></option>
+        <option value="draft" <?= $st==='draft'?'selected':''; ?>><?= __('admin.content.status.draft') ?></option>
+        <option value="published" <?= $st==='published'?'selected':''; ?>><?= __('admin.content.status.published') ?></option>
+        <option value="archived" <?= $st==='archived'?'selected':''; ?>><?= __('admin.content.status.archived') ?></option>
       </select>
 
-      <button class="btn btn-primary">تصفية</button>
+      <button class="btn btn-primary"><?= __('common.actions.filter') ?></button>
     </div>
   </div>
 </form>
@@ -55,12 +55,12 @@ $isAdmin = (session_status() === PHP_SESSION_ACTIVE || @session_start() === null
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr class="text-right text-sm font-semibold text-gray-700 uppercase tracking-wider">
-          <th class="px-6 py-4">عنوان المحتوى</th>
-          <th class="px-6 py-4">النوع</th>
-          <th class="px-6 py-4">النقاط</th>
-          <th class="px-6 py-4">المدة</th>
-          <th class="px-6 py-4">الحالة</th>
-          <th class="px-6 py-4">الإجراءات</th>
+          <th class="px-6 py-4"><?= __('admin.content.index.table.headers.title') ?></th>
+          <th class="px-6 py-4"><?= __('admin.content.index.table.headers.type') ?></th>
+          <th class="px-6 py-4"><?= __('admin.content.index.table.headers.points') ?></th>
+          <th class="px-6 py-4"><?= __('admin.content.index.table.headers.duration') ?></th>
+          <th class="px-6 py-4"><?= __('admin.content.index.table.headers.status') ?></th>
+          <th class="px-6 py-4"><?= __('admin.content.index.table.headers.actions') ?></th>
         </tr>
       </thead>
       <tbody class="bg-white divide-y divide-gray-200 text-base">
@@ -76,25 +76,31 @@ $isAdmin = (session_status() === PHP_SESSION_ACTIVE || @session_start() === null
             </td>
             <td class="px-6 py-4 text-gray-600"><?= htmlspecialchars($it['type']) ?></td>
             <td class="px-6 py-4 text-gray-600"><?= (int)$it['reward_points'] ?></td>
-            <td class="px-6 py-4 text-gray-600"><?= (int)$it['est_duration'] ?> د</td>
+            <td class="px-6 py-4 text-gray-600"><?= (int)$it['est_duration'] ?> <?= __('common.time.minutes_short') ?></td>
             <td class="px-6 py-4">
               <?php
                 $statusVal = (string)($it['publish_status'] ?? 'draft');
                 $badgeClass = 'badge-secondary';
                 if ($statusVal === 'published') $badgeClass = 'badge-success';
                 elseif ($statusVal === 'archived') $badgeClass = 'badge-warning';
+                $statusLabels = [
+                  'draft' => __('admin.content.status.draft'),
+                  'published' => __('admin.content.status.published'),
+                  'archived' => __('admin.content.status.archived')
+                ];
+                $statusLabel = $statusLabels[$statusVal] ?? __('admin.content.status.unknown');
               ?>
-              <span class="badge <?= $badgeClass ?>"><?= htmlspecialchars($statusVal) ?></span>
+              <span class="badge <?= $badgeClass ?>"><?= htmlspecialchars($statusLabel) ?></span>
             </td>
             <td class="px-6 py-4">
               <div class="flex items-center gap-2">
                 <?php if ($isAdmin): ?>
-                  <a class="text-gray-400 hover:text-primary text-xl" title="تعديل" href="<?= $basePath ?>/admin/content/edit?id=<?= (int)$it['id'] ?>">
+                  <a class="text-gray-400 hover:text-primary text-xl" title="<?= __('common.actions.edit') ?>" href="<?= $basePath ?>/admin/content/edit?id=<?= (int)$it['id'] ?>">
                     <i class="ri-edit-line"></i>
                   </a>
-                  <form method="post" action="<?= $basePath ?>/admin/content/delete" class="inline" onsubmit="return confirm('حذف هذا المحتوى؟');">
+                  <form method="post" action="<?= $basePath ?>/admin/content/delete" class="inline" onsubmit="return confirm('<?= __('admin.content.index.confirm_delete') ?>');">
                     <input type="hidden" name="id" value="<?= (int)$it['id'] ?>">
-                    <button class="text-gray-400 hover:text-red-500 text-xl" title="حذف"><i class="ri-delete-bin-line"></i></button>
+                    <button class="text-gray-400 hover:text-red-500 text-xl" title="<?= __('common.actions.delete') ?>"><i class="ri-delete-bin-line"></i></button>
                   </form>
                 <?php endif; ?>
               </div>
@@ -103,7 +109,7 @@ $isAdmin = (session_status() === PHP_SESSION_ACTIVE || @session_start() === null
         <?php endforeach; ?>
         <?php if (empty($items)): ?>
           <tr>
-            <td colspan="6" class="px-6 py-8 text-center text-gray-500 text-lg">لا توجد عناصر</td>
+            <td colspan="6" class="px-6 py-8 text-center text-gray-500 text-lg"><?= __('common.table.no_records') ?></td>
           </tr>
         <?php endif; ?>
       </tbody>


### PR DESCRIPTION
## Summary
- add a localization helper and ensure it is loaded during configuration
- introduce English and Arabic translation files covering shared labels and admin content text
- update the admin content index and create templates to consume the new translation keys

## Testing
- php -l views/admin/content/index.php
- php -l views/admin/content/create.php

------
https://chatgpt.com/codex/tasks/task_e_68dc0f6475d4832bbc959805245ee372